### PR TITLE
Header de User Agent

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -75,6 +75,8 @@ class Connection
         curl_setopt($ch, CURLOPT_POST, TRUE);
 
         curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+        
+        curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
             "Content-Type: application/json",


### PR DESCRIPTION
Recentemente comecei a receber o erro "É obrigatório preencher User-Agent no cabeçalho da requisição" ao criar link de pagamento, esse PR apenas adiciona o user agent no header.