### PR TITLE
correcao  User-Agent

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -35,7 +35,7 @@ class Connection
         curl_setopt($ch, CURLOPT_URL, $this->base_url . '/v3' . $url . $option);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
         curl_setopt($ch, CURLOPT_HEADER, FALSE);
-
+        curl_setopt($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
 
         if (empty($this->headers)) {
             $this->headers = array(


### PR DESCRIPTION
correção do erro "É obrigatório preencher User-Agent no cabeçalho da requisição", ao consultar todos os clientes no caminho 
$asaas->cliente()->getAll($array);
![Captura de tela de 2024-07-22 19-17-40](https://github.com/user-attachments/assets/c82d358a-7ab9-4750-9cfc-a0b53d49d5d0)
