### PR TITLE
FEAT: Adição de rota para listar cobranças de um parcelamento

### DIFF
--- a/src/Parcelamento.php
+++ b/src/Parcelamento.php
@@ -40,6 +40,12 @@ class Parcelamento
         return $this->http->get('/installments/' . $id);
     }
 
+    // Retorna as cobranças de um parcelamento de acordo com o Id do parcelamento
+    public function getPaymentsById($id)
+    {
+        return $this->http->get("/installments/{$id}/payments");
+    }
+
     // Retorna os dados da cobrança de acordo com o Id
     public function getBeefPdf($id)
     {

--- a/src/Parcelamento.php
+++ b/src/Parcelamento.php
@@ -41,9 +41,9 @@ class Parcelamento
     }
 
     // Retorna as cobranças de um parcelamento de acordo com o Id do parcelamento
-    public function getPaymentsById($id)
+    public function getPaymentsById($id, $limit = 12)
     {
-        return $this->http->get("/installments/{$id}/payments");
+        return $this->http->get("/installments/{$id}/payments?limit={$limit}");
     }
 
     // Retorna os dados da cobrança de acordo com o Id


### PR DESCRIPTION
Recentemente entrei em contato com o suporte do Asaas, perguntando sobre o retorno da API na criação de uma cobrança parcelada. Pois os dados retornados pelo create são apenas da primeira parcela.

Eles me recomendaram utilizar a rota [Listar cobranças de um parcelamento](https://docs.asaas.com/reference/listar-cobran%C3%A7as-de-um-parcelamento) para retornar todas as cobranças de uma `installment`

Como o pacote não possui essa rota, atualmente tenho utilizado a getById e passando como parâmetro `"{id}/payments"` mas acredito que seria útil termos uma rota bem definida para isso