### PR TITLE
Ajuste no connection.php adicionado User-Agent put e delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asaas SDK
+# Asaas @CodePhix
 
 SDK não-oficial de integração á API do serviço www.asaas.com
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Asaas @CodePhix
+# Asaas SDK
 
 SDK não-oficial de integração á API do serviço www.asaas.com
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -117,6 +117,7 @@ class Connection
         CURLOPT_FOLLOWLOCATION => true,
         CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         CURLOPT_CUSTOMREQUEST => 'PUT',
+        CURLOPT_USERAGENT => $_SERVER['HTTP_USER_AGENT'] ?? 'Unknown',
         CURLOPT_POSTFIELDS => $params,
         CURLOPT_HTTPHEADER => array(
             'Content-Type: application/json',
@@ -153,6 +154,7 @@ class Connection
           CURLOPT_FOLLOWLOCATION => true,
           CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
           CURLOPT_CUSTOMREQUEST => 'DELETE',
+          CURLOPT_USERAGENT => $_SERVER['HTTP_USER_AGENT'] ?? 'Unknown',
           CURLOPT_HTTPHEADER => array(
             'Accept: application/json',
             'access_token: '. $this->api_key


### PR DESCRIPTION
é necessário ter o user agent para enviar requições put e delete caso contrario a api do assas ira retornar o seguinte erro

"É obrigatório preencher User-Agent no cabeçalho da requisição"